### PR TITLE
update readme config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ type RegexSelector<T extends Record<string, string>> = TextContentSelector & {
   default?: T;
 }
 ```
-```json
+```jsonc
 {
   "name": string,
   "url": string,


### PR DESCRIPTION
Updated the preview of the json config block in the readme to be `jsonc` instead of `json`. This just makes the syntax highlighting nicer in the README