### PR TITLE
fix(matrix): Change Matrix room name to use category.name

### DIFF
--- a/src/modules/publishers/implementations/matrix.ts
+++ b/src/modules/publishers/implementations/matrix.ts
@@ -196,7 +196,7 @@ class MatrixPublisher extends MarkdownPublisher {
       logger.info("Room does not exist")
       // Create the room
       logger.info(`Creating the room - name ${roomAlias} - alias ${roomAlias}`)
-      const name = `scrapper-${category}`
+      const name = `scrapper-${category.name}`
       const { room_id: roomId } = await this.client.createRoom({
         name,
         topic: ` for ${category}`,


### PR DESCRIPTION
Updated matrix room creation init to use category.name. It was currently broken because it was using the category object to create the room name.