### PR TITLE
Wireguard container detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Implemented publishers:
 
 The service is designed to be scalable and can be deployed on multiple instances.
 
-### VPN
+### VPN (Wireguard)
 
-The docker compose includes a Wireguard client that allows the workers to scrape and grab the broadcasts from the web pages through a VPN.
-The used configuration file is ./wg0.conf.
+The docker has a cron that runs `./scripts/gateway.sh`.
+This script checks if a container named `wireguard` can be pinged, if it can, the default gateway of the container (server, worker, init) is set to the ip of the `wireguard` container.
 
 ## Installation
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+service cron start
+
+# The command set in docker compose 
+yarn run $1

--- a/scripts/gateway.sh
+++ b/scripts/gateway.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Function to get the container IP address using ping
+get_container_ip() {
+  container_name=$1
+  ip=$(dig +short $container_name)
+  echo $ip
+}
+
+# Function to delete the default gateway and set a new one
+set_default_gateway() {
+  new_gateway=$1
+
+  # Check if the new gateway is valid
+  if [ -z "$new_gateway" ]; then
+    echo "No IP address found for container. Exiting..."
+    exit 1
+  fi
+
+  # Delete the current default gateway
+  echo "Deleting current default gateway..."
+  ip route del default
+
+  # Set the new default gateway
+  echo "Setting new default gateway to $new_gateway..."
+  ip route add default via $new_gateway
+
+  echo "Default gateway updated to $new_gateway"
+}
+
+# Main script execution
+
+container_name="wireguard"  # Replace with your container name
+container_ip=$(get_container_ip $container_name)
+
+if [ -n "$container_ip" ]; then
+  echo "Found IP address for $container_name: $container_ip"
+  set_default_gateway $container_ip
+else
+  echo "Failed to get IP address for container $container_name."
+fi


### PR DESCRIPTION
Hello, I've tried something to allow the server, worker and init containers to detect if a wireguard container is running and available.

If so, then the container deletes the current default gateway and set it to the broadcastarr-wg container ip.

It feels as a good way to allow users to use a VPN without enforcing it.
But as it is a root command, that makes me add the node user in the sudoers without password, and I don't feel super great about this.

I'd love some feedback @lukeberry99 @aurvandel