### PR TITLE
fix(urlJoin) - url encode arguments

### DIFF
--- a/src/utils/urlJoin.ts
+++ b/src/utils/urlJoin.ts
@@ -3,6 +3,6 @@ import { join } from "path"
 import env from "../config/env"
 
 export default function urlJoin(apiKey: string, ...args: string[]): string {
-  const url = join("api", ...args, `?apiKey=${apiKey}`)
+  const url = join("api", encodeURI(join(...args)), `?apiKey=${apiKey}`)
   return `${env.remoteUrl}/${url}`
 }


### PR DESCRIPTION
Discord doesn't like spaces in the url. I encoded the arguments in the urlJoin function to replace spaces with %20.

![image](https://github.com/user-attachments/assets/a254bb2e-9896-46da-94d5-8d463c1dd601)
